### PR TITLE
Fix register kind twice exception.

### DIFF
--- a/src/com/streamhead/gae/paypal/PayPalApplication.java
+++ b/src/com/streamhead/gae/paypal/PayPalApplication.java
@@ -31,6 +31,10 @@ import com.vaadin.ui.Table;
 import com.vaadin.ui.Window;
 
 public class PayPalApplication extends Application {
+
+  static {
+    ObjectifyService.register(IPNMessage.class);
+  }
 	
 	private static final long serialVersionUID = 1L;
 	protected static final PayPalEnvironment environment = PayPalEnvironment.SANDBOX;
@@ -82,7 +86,7 @@ public class PayPalApplication extends Application {
 	
 	private void loadIPNMessages() {
 		ipnTable.removeAllItems();
-		ObjectifyService.register(IPNMessage.class);
+
 		Query<IPNMessage> messages = ObjectifyService.begin().query(IPNMessage.class);
 		for(IPNMessage m : messages)
 		{

--- a/src/com/streamhead/gae/paypal/ipn/IPNServlet.java
+++ b/src/com/streamhead/gae/paypal/ipn/IPNServlet.java
@@ -49,9 +49,15 @@ public class IPNServlet extends HttpServlet {
 	
 	private final Transport transport = new HttpPost();
     private final Objectify ofy;
+
+    // Register in static initializer to prevent exceptions.
+    // java.lang.IllegalArgumentException: Attempted to register kind 'IPNMessage' twice
+    // http://code.google.com/p/objectify-appengine/wiki/BestPractices
+    static {
+        ObjectifyService.register(IPNMessage.class);
+    }
     
     public IPNServlet() {
-    	ObjectifyService.register(IPNMessage.class);
     	ofy = ObjectifyService.begin();
     }
     


### PR DESCRIPTION
I updated to:
- objectify-3.0.1 
- vaadin-6.6.6.
- appengine-java-sdk-1.5.4

After fixing this bug, the PayPal sandbox reports "IPN successfully sent."

`PayPalApplication.java` has the same issue which is breaking the viewer.
